### PR TITLE
チルタリス、タブンネ、シュシュプ

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -70,8 +70,8 @@ function App() {
                 fullWidth
             >
                 <DialogTitle>
-                    <Typography variant="h5">このウェブサイトの内容は架空のもので実在しません</Typography>
-                    <Typography variant="body1">以下の事項に注意して閲覧してください</Typography>
+                    <Typography variant="h5" component="div">このウェブサイトの内容は架空のもので実在しません</Typography>
+                    <Typography variant="body1" component="div">以下の事項に注意して閲覧してください</Typography>
                 </DialogTitle>
                 <DialogContent>
                     <Typography variant='body2'>初めての方はこちらをご覧ください→<RouterLink to='/about' onClick={closeWarnModal}>大府市営地下鉄について</RouterLink></Typography>

--- a/src/components/DepartureCard.jsx
+++ b/src/components/DepartureCard.jsx
@@ -6,6 +6,7 @@ import {
     Button,
     Card,
     CardContent,
+    Container,
     Dialog,
     DialogActions,
     DialogContent,
@@ -138,24 +139,7 @@ function DepartureCard({ station, addButton = false, removeButton = false }) {
                                 ))}
                             </Box>
                         ) : (
-                            <Table sx={{ tableLayout: 'fixed', width: '100%' }}>
-                    
-                                <TableRow sx={{
-                                    '& .MuiTableCell-root': {
-                                        overflow: 'hidden',
-                                        minHeight: '15px',
-                                        width: '100%',
-                                        padding: '0'
-                                    },
-                                    '&:last-child td, &:last-child th': {
-                                        border: 0
-                                    }
-                                }}>
-                                    <TableCell sx={{ px: 0, width: '100%' }}>
-                                        <Typography variant='h6' sx={{ textAlign: 'center' }}>本日の運転は終了しました</Typography>
-                                    </TableCell>
-                                </TableRow>
-                            </Table>
+                            <Typography variant='h6' sx={{ textAlign: 'center' }}>本日の運転は終了しました</Typography>
                         )}
                     </Stack>
 
@@ -211,8 +195,8 @@ function DepartureCard({ station, addButton = false, removeButton = false }) {
                 <DialogTitle>
                     {isOpenShowMore && (
                         <>
-                            <Typography graphy variant="h6">{station.name}</Typography>
-                            <Typography variant="subtitle1">{`${direction?.stationName} 方面`}</Typography>
+                            <Typography variant="h6" component="div">{station.name}</Typography>
+                            <Typography variant="subtitle1" component="div">{`${direction?.stationName} 方面`}</Typography>
                         </>
                     )}
                 </DialogTitle>

--- a/src/components/DepartureCard.jsx
+++ b/src/components/DepartureCard.jsx
@@ -121,7 +121,7 @@ function DepartureCard({ station, addButton = false, removeButton = false }) {
                             onClick={() => {
                                 setIsOpenMobileSelector({
                                     open: true,
-                                    options: stations[station.name]?.directions.map(d => ({ value: d, label: `${d.stationName}方面`, route: d.route }))
+                                    options: directionOptions
                                 });
                                 navigate(`?modal=directionSelector-${station.name}`);
                             }}

--- a/src/components/DepartureSection.jsx
+++ b/src/components/DepartureSection.jsx
@@ -148,7 +148,7 @@ export default function DepartureSection() {
                 <DialogActions>
                     <Button onClick={() => {
                         navigate('/home');
-                        setIsOpenShowMore(false);
+                        setIsShowSearch(false);
                     }}>閉じる</Button>
                 </DialogActions>
           </Dialog>

--- a/src/components/DepartureSection.jsx
+++ b/src/components/DepartureSection.jsx
@@ -83,7 +83,7 @@ export default function DepartureSection() {
 
           <Stack direction="row" spacing={2} sx={{ overflowX: 'auto', whiteSpace: 'nowrap', flexWrap: 'nowrap', pb: 1, scrollSnapType: { xs: 'x mandatory', md: 'none'} }}>
             {myStations.map(sta => 
-              <Box sx={{ scrollSnapAlign: { xs: 'center', md: 'none'} }}>
+              <Box sx={{ scrollSnapAlign: { xs: 'center', md: 'none'} }} key={sta.name}>
                 <DepartureCard key={`my-${sta.name}`} station={sta} removeButton />
               </Box>
             )}
@@ -113,7 +113,7 @@ export default function DepartureSection() {
               fullWidth
           >
               <DialogTitle>
-                  <h3>マイ駅・停留所を追加</h3>
+                  <Typography variant="h6" component="div">マイ駅・停留所を追加</Typography>
               </DialogTitle>
                 <DialogContent>
                     <Select


### PR DESCRIPTION
## チルタリス
スマホ表示の時にバス停の方面を選択するボタンを押すと真っ白になるのを直した

## タブンネ
コンソールに出てたエラーとかを直した

## シュシュプ
マイ駅・停留所を追加ダイアログで閉じるボタンが押せないのを直した